### PR TITLE
Custom docker images in connectable builds on resin-ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Custom docker images in connectable builds [Andrei]
 * Bump meta-resin to include connectable builds [Andrei]
 * Add support for optional supervisor image [Andrei]
 * Update meta-resin to v1.2 [Andrei]

--- a/layers/meta-resin-ts/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
+++ b/layers/meta-resin-ts/recipes-containers/docker-disk/docker-resin-supervisor-disk.bbappend
@@ -1,5 +1,5 @@
 # ts4900
-TARGET_REPOSITORY_ts4900 = "resin/armv7hf-supervisor"
+SUPERVISOR_REPOSITORY_ts4900 = "resin/armv7hf-supervisor"
 
 # ts7700
-TARGET_REPOSITORY_ts7700 = "resin/armel-supervisor"
+SUPERVISOR_REPOSITORY_ts7700 = "resin/armel-supervisor"


### PR DESCRIPTION
Connects to resin-os/meta-resin#133-supervisor-custom-image-tag
@telphan @floion
