### PR TITLE
resin-extend-expand.bbappend: Fix SRC_URI_append

### DIFF
--- a/layers/meta-resin-ts/recipes-support/resin-extend-expand/resin-extend-expand.bbappend
+++ b/layers/meta-resin-ts/recipes-support/resin-extend-expand/resin-extend-expand.bbappend
@@ -1,3 +1,3 @@
 FILESEXTRAPATHS_prepend_ts7700 := "${THISDIR}/${PN}:"
 
-SRC_URI_append_ts7700 = "file://0001-Fix-the-bound-to-a-hard-limit.patch;patchdir=${WORKDIR}"
+SRC_URI_append_ts7700 = " file://0001-Fix-the-bound-to-a-hard-limit.patch;patchdir=${WORKDIR}"


### PR DESCRIPTION
_append needs an explicit leading space

Signed-off-by: Florin Sarbu <florin@resin.io>