### PR TITLE
recipes-kernel/linux: Add fno-pic CFLAGS for modules

### DIFF
--- a/layers/meta-resin-ts/recipes-kernel/linux/linux-technologic_%.bbappend
+++ b/layers/meta-resin-ts/recipes-kernel/linux/linux-technologic_%.bbappend
@@ -4,6 +4,8 @@ COMPATIBLE_MACHINE = "ts4900"
 
 FILESEXTRAPATHS_prepend_ts4900 := "${THISDIR}/${PN}:"
 
+EXTRA_OEMAKE = " 'CFLAGS_MODULE=-fno-pic'"
+
 SRC_URI_append_ts4900 = " \
     file://0001-ovl-allow-zero-size-xattr.patch \
     file://0002-ovl-use-a-minimal-buffer-in-ovl_copy_xattr.patch \


### PR DESCRIPTION
The kernel modules need to be compiled with the -fno-pic flag
to avoid errors of this type:

[   14.213347] uio: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)
[   14.273328] uio: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)
[   14.333581] uio: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)
.......
[   15.893587] xt_owner: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)
[   15.937744] xt_owner: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)
[   16.043144] xt_owner: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)
[   16.087544] xt_owner: Unknown symbol _GLOBAL_OFFSET_TABLE_ (err 0)

The flags don't apply for OOT modules.

Changelog-entry: Added fno-pic flag for modules
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>