### PR TITLE
ts4900.coffee: Set private to false for the public device types

### DIFF
--- a/ts4900.coffee
+++ b/ts4900.coffee
@@ -19,6 +19,7 @@ module.exports =
 	name: 'Technologic TS-4900'
 	arch: 'armv7hf'
 	state: 'released'
+	private: false
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Changelog-entry: Set private to false in .coffee files for the public device types
Signed-off-by: Florin Sarbu <florin@balena.io>